### PR TITLE
Change state manager console warning to info to reduce logs clutter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,15 +89,13 @@ export class InMemoryStateManager implements StateManager {
 
   constructor() {
     if (process.env.NODE_ENV !== 'test') {
-      const yellowColor = '\x1b[33m%s\x1b[0m'
-
       const warning = [
         '[a1pubsub]',
         'Currently using the `InMemoryStateManager`',
         'This state manager is only suitable for single-instance applications',
       ].join(' - ')
 
-      console.warn(yellowColor, warning)
+      console.info(warning)
     }
 
     this.cache = new Map()


### PR DESCRIPTION
Currently the logs of any service using `a1pubsub` are filled with warnings about the default state manager, changing this to info means those logs can be filtered out when looking for actual errors.